### PR TITLE
Update header names

### DIFF
--- a/src/authorizeRequest/authorizeRequest.js
+++ b/src/authorizeRequest/authorizeRequest.js
@@ -15,7 +15,7 @@ async function authorizeRequest(userRequest) {
     convertResponseTypes: false,
   });
 
-  const { 'X-Bu-Shib-Username': userName = '' } = headers;
+  const { buPrincipalNameID: userName = '' } = headers;
 
   // Get the group name from the uri, it is the segment after the "/__restricted/" segment.
   // Should probably sanitize the path segments here, to only valid url characters just in case.

--- a/src/authorizeRequest/authorizeRequest.test.js
+++ b/src/authorizeRequest/authorizeRequest.test.js
@@ -6,7 +6,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/__restricted/entire-bu-community/image.jpg',
       headers: {
-        'X-Bu-Shib-Username': 'testUser',
+        buPrincipalNameID: 'testUser',
       },
     };
     const result = await authorizeRequest(userRequest);
@@ -27,7 +27,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/__restricted/somegroup/image.jpg',
       headers: {
-        'X-Bu-Shib-Username': 'user2',
+        buPrincipalNameID: 'user2',
       },
     };
     const result = await authorizeRequest(userRequest);

--- a/src/authorizeRequest/checkUserAccess.js
+++ b/src/authorizeRequest/checkUserAccess.js
@@ -1,9 +1,9 @@
 function checkUserAccess(rules, headers) {
   // Destructure the header object to get the shib attributes, with defaults.
   const {
-    'X-Bu-Shib-Username': userName = '',
-    'X-Bu-Shib-Primary-Affiliation': userAffiliation = '',
-    'X-Bu-Shib-Entitlement': userEntitlements = [],
+    buPrincipalNameID: userName = '',
+    affiliation: userAffiliation = '',
+    entitlement: userEntitlements = [],
   } = headers;
 
   // Unpack the rules, with defaults.

--- a/src/authorizeRequest/checkUserAccess.test.js
+++ b/src/authorizeRequest/checkUserAccess.test.js
@@ -28,27 +28,27 @@ describe('checkUserAccess', () => {
 
   it('should return true if the user is in the list of users', () => {
     const headers = {
-      'X-Bu-Shib-Username': 'testuser',
-      'X-Bu-Shib-Primary-Affiliation': '',
-      'X-Bu-Shib-Entitlement': [],
+      buPrincipalNameID: 'testuser',
+      affiliation: '',
+      entitlement: [],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });
 
   it('should return true if the user is in the list of affiliations', () => {
     const headers = {
-      'X-Bu-Shib-Username': 'someuser-not-in-the-list',
-      'X-Bu-Shib-Primary-Affiliation': 'staff',
-      'X-Bu-Shib-Entitlement': [],
+      buPrincipalNameID: 'someuser-not-in-the-list',
+      affiliation: 'staff',
+      entitlement: [],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });
 
   it('should return true if the user has an entitlement', () => {
     const headers = {
-      'X-Bu-Shib-Username': 'someuser-not-in-the-list',
-      'X-Bu-Shib-Primary-Affiliation': 'student',
-      'X-Bu-Shib-Entitlement': ['https://iam.bu.edu/entitlements/some-entitlement'],
+      buPrincipalNameID: 'someuser-not-in-the-list',
+      affiliation: 'student',
+      entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });


### PR DESCRIPTION
Apache forwards the authentication headers with pre-determined names, so this change matches those header names.