### PR TITLE
Add back lambda invoke permissions

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -77,6 +77,11 @@ Resources:
               Action:
                 - secretsmanager:GetSecretValue
             - Effect: Allow
+              Resource:
+                - !GetAtt ResizeFunction.Arn
+              Action: 
+                - lambda:InvokeFunction
+            - Effect: Allow
               Resource: 
                 - !Sub arn:aws:s3:::${S3Bucket}
                 - !Sub arn:aws:s3:::${S3Bucket}/*


### PR DESCRIPTION
I thought it was unnecessary for the IAM user to have direct invoke access to the Lambda, that access to the object lambda access point was sufficient.

Trying this out though, it seems like that's not enough because I was seeing this error when using the user's access token:
```
The caller is not authorized to invoke the Lambda function. (Lambda service Status Code: 403 | Error Code: AccessDeniedException | Error Message: User: arn:aws:iam::***:user/jaydub-s3-object-lambda-user is not authorized to perform: lambda:InvokeFunction on resource: arn:aws:lambda:us-east-1:***:function:jaydub-s3-object-lambda-ResizeFunction-feHTp46D3fGZ because no identity-based policy allows the lambda:InvokeFunction action
```

This change adds back just the invoke permission for the specific lambda, in my testing this fixes the permission error.