### PR TITLE
Fix case sensitive headers

### DIFF
--- a/src/authorizeRequest/authorizeRequest.js
+++ b/src/authorizeRequest/authorizeRequest.js
@@ -16,7 +16,7 @@ async function authorizeRequest(userRequest) {
   });
 
   const {
-    eppn = '',
+    Eppn: eppn = '',
     'X-Forwarded-Host': forwardedHost = '',
   } = headers;
 

--- a/src/authorizeRequest/authorizeRequest.test.js
+++ b/src/authorizeRequest/authorizeRequest.test.js
@@ -6,7 +6,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/__restricted/entire-bu-community/image.jpg',
       headers: {
-        eppn: 'testUser@bu.edu',
+        Eppn: 'testUser@bu.edu',
         'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
       },
     };
@@ -30,7 +30,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/__restricted/somegroup/image.jpg',
       headers: {
-        eppn: 'user2@bu.edu',
+        Eppn: 'user2@bu.edu',
         'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
       },
     };
@@ -47,7 +47,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/files/__restricted/somegroup/image.jpg',
       headers: {
-        eppn: 'user2@bu.edu',
+        Eppn: 'user2@bu.edu',
         'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
       },
     };
@@ -60,7 +60,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/__restricted/somegroup/image.jpg',
       headers: {
-        'X-Real-IP': '128.197.30.30',
+        'X-Real-Ip': '128.197.30.30',
         'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
       },
     };
@@ -72,7 +72,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/__restricted/somegroup/image.jpg',
       headers: {
-        'X-Real-IP': '127.0.0.1',
+        'X-Real-Ip': '127.0.0.1',
         'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
       },
     };
@@ -84,7 +84,7 @@ describe('authorizeRequest', () => {
     const userRequest = {
       url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/__restricted/othergroup/image.jpg',
       headers: {
-        'X-Real-IP': '128.197.30.30',
+        'X-Real-Ip': '128.197.30.30',
         'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
       },
     };

--- a/src/authorizeRequest/checkNetworkAccess/checkNetworkAccess.js
+++ b/src/authorizeRequest/checkNetworkAccess/checkNetworkAccess.js
@@ -4,7 +4,7 @@ const rangeSets = require('./ranges.json');
 function checkNetworkAccess(rules, headers) {
   // Get the user ip address from the headers, with a default value of an empty string.
   const {
-    'X-Real-IP': userIp = '',
+    'X-Real-Ip': userIp = '',
   } = headers;
 
   // Get the campus names from the rules object that stores network rules, with a default value of an empty array.

--- a/src/authorizeRequest/checkNetworkAccess/checkNetworkAccess.test.js
+++ b/src/authorizeRequest/checkNetworkAccess/checkNetworkAccess.test.js
@@ -2,25 +2,25 @@ const { checkNetworkAccess } = require('./checkNetworkAccess');
 
 describe('checkNetworkAccess', () => {
   it('should return true if the user network IP address is in the allowed ranges from the crc campus', () => {
-    const headers = { 'X-Real-IP': '128.197.30.30' };
+    const headers = { 'X-Real-Ip': '128.197.30.30' };
     const rules = { ranges: ['crc'] };
     expect(checkNetworkAccess(rules, headers)).toBe(true);
   });
 
   it('should return false if the user network IP address is not in the allowed ranges from the crc campus', () => {
-    const headers = { 'X-Real-IP': '128.100.0.1' };
+    const headers = { 'X-Real-Ip': '128.100.0.1' };
     const rules = { ranges: ['crc'] };
     expect(checkNetworkAccess(rules, headers)).toBe(false);
   });
 
   it('should return true if the user network IP address is in the allowed ranges from the medical campus', () => {
-    const headers = { 'X-Real-IP': '155.41.140.5' };
+    const headers = { 'X-Real-Ip': '155.41.140.5' };
     const rules = { ranges: ['crc', 'mc'] };
     expect(checkNetworkAccess(rules, headers)).toBe(true);
   });
 
   it('should return false if the user network IP address is not in the allowed ranges from the medical campus', () => {
-    const headers = { 'X-Real-IP': '128.197.30.30' };
+    const headers = { 'X-Real-Ip': '128.197.30.30' };
     const rules = { ranges: ['mc'] };
     expect(checkNetworkAccess(rules, headers)).toBe(false);
   });

--- a/src/authorizeRequest/checkUserAccess.js
+++ b/src/authorizeRequest/checkUserAccess.js
@@ -1,9 +1,9 @@
 function checkUserAccess(rules, headers) {
   // Destructure the header object to get the shib attributes, with defaults.
   const {
-    eppn = '',
-    'primary-affiliation': userAffiliation = '',
-    entitlement: userEntitlements = [],
+    Eppn: eppn = '',
+    'Primary-Affiliation': userAffiliation = '',
+    Entitlement: userEntitlements = [],
   } = headers;
 
   // Get the userName as the unscoped eppn ( e.g. the email without the @domain).

--- a/src/authorizeRequest/checkUserAccess.test.js
+++ b/src/authorizeRequest/checkUserAccess.test.js
@@ -10,45 +10,45 @@ const exampleUserRules = {
 describe('checkUserAccess', () => {
   it('should return false if there is no logged in user', () => {
     const headers = {
-      eppn: '',
-      'X-Bu-Shib-Primary-Affiliation': '',
-      'X-Bu-Shib-Entitlement': [],
+      Eppn: '',
+      'Primary-Affiliation': '',
+      Entitlement: [],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
   });
 
   it('should return false if the user attibutes dont match the rules', () => {
     const headers = {
-      eppn: 'not-listed-user@bu.edu',
-      'X-Bu-Shib-Primary-Affiliation': 'faculty',
-      'X-Bu-Shib-Entitlement': ['not-an-entitlement', 'notentitlement2'],
+      Eppn: 'not-listed-user@bu.edu',
+      'Primary-Affiliation': 'faculty',
+      Entitlement: ['not-an-entitlement', 'notentitlement2'],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
   });
 
   it('should return true if the user is in the list of users', () => {
     const headers = {
-      eppn: 'testuser@bu.edu',
-      'primary-affiliation': '',
-      entitlement: [],
+      Eppn: 'testuser@bu.edu',
+      'Primary-Affiliation': '',
+      Entitlement: [],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });
 
   it('should return true if the user is in the list of affiliations', () => {
     const headers = {
-      eppn: 'someuser-not-in-the-list@bu.edu',
-      'primary-affiliation': 'staff',
-      entitlement: [],
+      Eppn: 'someuser-not-in-the-list@bu.edu',
+      'Primary-Affiliation': 'staff',
+      Entitlement: [],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });
 
   it('should return true if the user has an entitlement', () => {
     const headers = {
-      eppn: 'someuser-not-in-the-list@bu.edu',
-      'primary-affiliation': 'student',
-      entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
+      Eppn: 'someuser-not-in-the-list@bu.edu',
+      'Primary-Affiliation': 'student',
+      Entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });


### PR DESCRIPTION
All of a sudden, headers became

- title case
- case sensitive

I don't know how or why this changed, but this PR adapts the header parsing and unit testing to accommodate title case header names.
