### PR TITLE
Add --use-container to sam build

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,7 +12,6 @@
     push:
       branches:
         - main
-        - sam-use-container
   
   env:
     AWS_REGION: us-east-1


### PR DESCRIPTION
Otherwise the sharp library doesn't work, as it has compiled C libraries.