### PR TITLE
Delete original table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -161,14 +161,6 @@ Resources:
             Resource: '*'
   
   # DynamoDB table
-  AccessControlDynamoDB:
-    Type: AWS::Serverless::SimpleTable
-    Properties:
-      PrimaryKey:
-        Name: SiteAndGroupKey
-        Type: String
-      TableName: !Sub ${AWS::StackName}-AccessControl
-
   TempAccessControlDynamoDB:
     Type: AWS::Serverless::SimpleTable
     Properties:


### PR DESCRIPTION
Use the github action and SAM deploy to delete the original dynamodb table with the outdated primary key label.