### PR TITLE
Check for prescaled

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,9 +25,9 @@
     build-and-deploy:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4.1.7
         - uses: aws-actions/setup-sam@v2
-        - uses: actions/setup-node@v2
+        - uses: actions/setup-node@v4.0.3
           with:
             node-version: '18'
         - uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,8 +4,8 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: '18'
       - run: npm ci

--- a/src/getOrCreateObject/getOrCreateObject.test.js
+++ b/src/getOrCreateObject/getOrCreateObject.test.js
@@ -45,6 +45,15 @@ s3Mock.on(GetObjectCommand, {
   Body: singlePixelJpgReadable,
 });
 
+// Define a pre-scaled object in the bucket,
+// with a scale factor baked into the name of the original.
+s3Mock.on(GetObjectCommand, {
+  Bucket: 'test-bucket',
+  Key: 'original_media/www.bu.edu/somesite/files/01/prescaled-758x460.jpg',
+}).resolves({
+  Body: singlePixelJpgReadable,
+});
+
 describe('getOrCreateObject', () => {
   it('should return an object if it exists', async () => {
     const result = await getOrCreateObject(
@@ -88,5 +97,16 @@ describe('getOrCreateObject', () => {
       'www.bu.edu',
     );
     expect(result.Code).toEqual('NoSuchKey');
+  });
+
+  it('should return a pre-scaled original object if it exists', async () => {
+    const result = await getOrCreateObject(
+      {
+        url: 'https://example-1111.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/01/prescaled-758x460.jpg',
+        headers: { },
+      },
+      'www.bu.edu',
+    );
+    expect(result.Body).toBeDefined();
   });
 });


### PR DESCRIPTION
"Prescaled" media are original files that have the `100x100.` file name signature that ought to designate them as scaled renders of an unscaled original file. These are files that we uploaded with a file name like "originally-uploaded-100x100.jpg".


This change:

- Adds an extra check that if the render file and the unscaled originals are not found, it will also look for a "prescaled" file in with the originals
- Adds a unit test to verify that this works.

I also tested this with a dev version of the OLAP, and it appears effective.

Included in this patch are version updates to out-of-date GitHub Actions.