### PR TITLE
Restrict 'Gravity Forms' uploads BU Community members

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -25,3 +25,12 @@ tags = "Service=\"websites\" Function=\"wordpress\" Project=\"bu-wp-to-cloud\" L
 image_repositories = []
 no-prompts = true
 
+[dev.deploy.parameters]
+stack_name = "wordpress-protected-s3-dev"
+resolve_s3 = true
+tags = "Service=\"websites\" Function=\"wordpress\" Project=\"bu-wp-to-cloud\" Landscape=\"dev\""
+s3_prefix = "wordpress-protected-s3-dev"
+region = "us-east-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
+image_repositories = []

--- a/src/app.js
+++ b/src/app.js
@@ -75,7 +75,7 @@ export async function handler(event) {
   // Check access restrictions.
   // Unrestricted items are always allowed, and should be sent with a cache control header to tell CloudFront to cache the item.
   // Will need to account for whole site protections here.
-  const isPublic = !userRequest.url.includes('__restricted') && !siteRule && !userRequest.url.includes('files/gravity_forms');
+  const isPublic = !userRequest.url.includes('__restricted') && !siteRule && !userRequest.url.includes('/files/gravity_forms/');
 
   // Check if the user is authorized to access the object (always true for public items).
   const authorized = isPublic ? true : await authorizeRequest(userRequest, siteRule, cachedRanges.ranges);

--- a/src/app.js
+++ b/src/app.js
@@ -75,7 +75,7 @@ export async function handler(event) {
   // Check access restrictions.
   // Unrestricted items are always allowed, and should be sent with a cache control header to tell CloudFront to cache the item.
   // Public items are those that do not have a __restricted segment in the URL, do not have a site rule,
-  // or are not in the gravity_forms directory; we are proctecting the gravity_forms directory.
+  // or are not in the gravity_forms directory; we are protecting the gravity_forms directory.
   const isPublic = !userRequest.url.includes('__restricted') && !siteRule && !userRequest.url.includes('/files/gravity_forms/');
 
   // Check if the user is authorized to access the object (always true for public items).

--- a/src/app.js
+++ b/src/app.js
@@ -74,7 +74,8 @@ export async function handler(event) {
 
   // Check access restrictions.
   // Unrestricted items are always allowed, and should be sent with a cache control header to tell CloudFront to cache the item.
-  // Will need to account for whole site protections here.
+  // Public items are those that do not have a __restricted segment in the URL, do not have a site rule,
+  // or are not in the gravity_forms directory; we are proctecting the gravity_forms directory.
   const isPublic = !userRequest.url.includes('__restricted') && !siteRule && !userRequest.url.includes('/files/gravity_forms/');
 
   // Check if the user is authorized to access the object (always true for public items).

--- a/src/app.js
+++ b/src/app.js
@@ -75,7 +75,7 @@ export async function handler(event) {
   // Check access restrictions.
   // Unrestricted items are always allowed, and should be sent with a cache control header to tell CloudFront to cache the item.
   // Will need to account for whole site protections here.
-  const isPublic = !userRequest.url.includes('__restricted') && !siteRule;
+  const isPublic = !userRequest.url.includes('__restricted') && !siteRule && !userRequest.url.includes('files/gravity_forms');
 
   // Check if the user is authorized to access the object (always true for public items).
   const authorized = isPublic ? true : await authorizeRequest(userRequest, siteRule, cachedRanges.ranges);

--- a/src/authorizeRequest/authorizeRequest.js
+++ b/src/authorizeRequest/authorizeRequest.js
@@ -44,6 +44,8 @@ async function authorizeRequest(userRequest, siteRule, networkRanges) {
     isRootSite = Object.keys(siteRule)[0] === domain;
   }
 
+  // Restrict files in the gravity_forms directory to the entire-bu-community group.
+  // This is hardcoded because gravity_forms always writes to this directory, and we protect it.
   if (!groupName && url.includes('/files/gravity_forms/')) {
     groupName = 'entire-bu-community';
   }

--- a/src/authorizeRequest/authorizeRequest.js
+++ b/src/authorizeRequest/authorizeRequest.js
@@ -44,7 +44,7 @@ async function authorizeRequest(userRequest, siteRule, networkRanges) {
     isRootSite = Object.keys(siteRule)[0] === domain;
   }
 
-  if (!groupName && url.includes('files/gravity_forms')) {
+  if (!groupName && url.includes('/files/gravity_forms/')) {
     groupName = 'entire-bu-community';
   }
 

--- a/src/authorizeRequest/authorizeRequest.js
+++ b/src/authorizeRequest/authorizeRequest.js
@@ -44,6 +44,10 @@ async function authorizeRequest(userRequest, siteRule, networkRanges) {
     isRootSite = Object.keys(siteRule)[0] === domain;
   }
 
+  if (!groupName && url.contains('files/gravity_forms')) {
+    groupName = 'entire-bu-community';
+  }
+
   // Detect if this is the root site by the position of the __restricted segment.
   // Not sure if this should be detected by position of '__restricted' or by proximity to 'files'.
   let siteName = isRootSite ? '' : pathSegments[indexOfRestricted - 2];

--- a/src/authorizeRequest/authorizeRequest.js
+++ b/src/authorizeRequest/authorizeRequest.js
@@ -44,7 +44,7 @@ async function authorizeRequest(userRequest, siteRule, networkRanges) {
     isRootSite = Object.keys(siteRule)[0] === domain;
   }
 
-  if (!groupName && url.contains('files/gravity_forms')) {
+  if (!groupName && url.includes('files/gravity_forms')) {
     groupName = 'entire-bu-community';
   }
 

--- a/src/authorizeRequest/authorizeRequest.test.js
+++ b/src/authorizeRequest/authorizeRequest.test.js
@@ -177,4 +177,16 @@ describe('authorizeRequest', () => {
     const result = await authorizeRequest(userRequest, siteRule, testRanges);
     expect(result).toBe(true);
   });
+
+  // Check that gravityforms files are protected by a login session, that is it has no EPPN header.
+  it('should return false if the request is for a gravityforms file and there is no logged in user', async () => {
+    const userRequest = {
+      url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/gravityforms/somefile.json',
+      headers: {
+        'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
+      },
+    };
+    const result = await authorizeRequest(userRequest, null, testRanges);
+    expect(result).toBe(false);
+  });
 });

--- a/src/authorizeRequest/authorizeRequest.test.js
+++ b/src/authorizeRequest/authorizeRequest.test.js
@@ -181,7 +181,7 @@ describe('authorizeRequest', () => {
   // Check that gravityforms files are protected by a login session, that is it has no EPPN header.
   it('should return false if the request is for a gravityforms file and there is no logged in user', async () => {
     const userRequest = {
-      url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/gravityforms/somefile.json',
+      url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/gravity_forms/somefile.json',
       headers: {
         'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
       },


### PR DESCRIPTION
This PR enforces that files under the `gravity_forms` directory require a valid BU login (entire-bu-community membership) before access.

- Hardcodes `entire-bu-community` group for `gravity_forms` paths in `authorizeRequest`
- Updates handler logic to treat `gravity_forms` uploads as non-public
- Adds a unit test for the unauthorized gravity_forms scenario and updates SAM config for dev deployments