### PR TITLE
Fix unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bu-protected-s3-object-lambda",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "Delivers asset from S3 through an object lambda with access restrictions and image resizing",
   "type": "module",
   "scripts": {

--- a/src/authorizeRequest/authorizeRequest.test.js
+++ b/src/authorizeRequest/authorizeRequest.test.js
@@ -201,15 +201,4 @@ describe('authorizeRequest', () => {
     const result = await authorizeRequest(userRequest, null, testRanges);
     expect(result).toBe(true);
   });
-  it('should return false if the request is for a restricted file and the userName is empty', async () => {
-    const userRequest = {
-      url: 'https://example-access-point.s3-object-lambda.us-east-1.amazonaws.com/somesite/files/__restricted/somegroup/somefile.json',
-      headers: {
-        Eppn: '',
-        'X-Forwarded-Host': 'example.host.bu.edu, example.host.bu.edu',
-      },
-    };
-    const result = await authorizeRequest(userRequest, null, testRanges);
-    expect(result).toBe(false);
-  });
 });

--- a/src/authorizeRequest/checkUserAccess.test.js
+++ b/src/authorizeRequest/checkUserAccess.test.js
@@ -63,22 +63,22 @@ describe('checkUserAccess', () => {
     };
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });
-});
 
-it('should return false if the userName is only whitespace', () => {
-  const headers = {
-    Eppn: '   @bu.edu',
-    'Primary-Affiliation': 'staff',
-    Entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
-  };
-  expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
-});
+  it('should return false if the userName is only whitespace', () => {
+    const headers = {
+      Eppn: '   @bu.edu',
+      'Primary-Affiliation': 'staff',
+      Entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
+    };
+    expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
+  });
 
-it('should return false if eppn is just the domain', () => {
-  const headers = {
-    Eppn: '@bu.edu',
-    'Primary-Affiliation': 'staff',
-    Entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
-  };
-  expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
+  it('should return false if eppn is just the domain', () => {
+    const headers = {
+      Eppn: '@bu.edu',
+      'Primary-Affiliation': 'staff',
+      Entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
+    };
+    expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
+  });
 });

--- a/src/authorizeRequest/checkUserAccess.test.js
+++ b/src/authorizeRequest/checkUserAccess.test.js
@@ -64,3 +64,21 @@ describe('checkUserAccess', () => {
     expect(checkUserAccess(exampleUserRules, headers)).toBe(true);
   });
 });
+
+it('should return false if the userName is only whitespace', () => {
+  const headers = {
+    Eppn: '   @bu.edu',
+    'Primary-Affiliation': 'staff',
+    Entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
+  };
+  expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
+});
+
+it('should return false if eppn is just the domain', () => {
+  const headers = {
+    Eppn: '@bu.edu',
+    'Primary-Affiliation': 'staff',
+    Entitlement: ['https://iam.bu.edu/entitlements/some-entitlement'],
+  };
+  expect(checkUserAccess(exampleUserRules, headers)).toBe(false);
+});

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "s3-object-lambda-app",
-    "version": "1.0.5",
+    "version": "1.0.7",
     "description": "",
     "main": "app.js",
     "type": "module",


### PR DESCRIPTION
I tested the previous unit test and it did not appear to fail when I blocked the empty user check. 

The problem with the original unit test is that is was testing an entirely blank username: `Eppn: ''`. What we need to check is that just the username is only whitespace or blank, but the domain is there like `  @bu.edu`.

Also it is probably better to locate it in the unit tests for the file being changed, not the parent.

This PR reverses that unit test and replaces it with unit tests on checkUsersAccess where the check is actually happening. These tests pass with the user check enabled and fail when it is omitted.